### PR TITLE
scripts/test: Use maxWorkers=4 when running on CI

### DIFF
--- a/packages/react-scripts/scripts/test.js
+++ b/packages/react-scripts/scripts/test.js
@@ -32,6 +32,9 @@ const argv = process.argv.slice(2);
 if (!process.env.CI && argv.indexOf('--coverage') < 0) {
   argv.push('--watch');
 }
+else {
+  argv.push('--maxWorkers=4');
+}
 
 // @remove-on-eject-begin
 // This is not necessary after eject because we embed config into package.json.


### PR DESCRIPTION
It seems that Jest runs much faster in Travis when it's ran with this
flag.  E.g. for one particular project, this made the frontend testing
time drop from 20 minutes to 2 minutes.