### PR TITLE
react-scripts webpack config: Fix CSS source maps

### DIFF
--- a/packages/react-scripts/config/webpack.config.prod.js
+++ b/packages/react-scripts/config/webpack.config.prod.js
@@ -218,6 +218,7 @@ module.exports = {
                             flexbox: 'no-2009',
                           }),
                         ],
+                        sourceMap: shouldUseSourceMap,
                       },
                     },
                   ],
@@ -260,6 +261,7 @@ module.exports = {
                             flexbox: 'no-2009',
                           }),
                         ],
+                        sourceMap: shouldUseSourceMap,
                       },
                     },
                     {


### PR DESCRIPTION
Add sourceMap option to postcss-loader too.

This fixes the following error for the SASS/SCSS files:

    Failed to compile.

    ./node_modules/font-awesome/scss/font-awesome.scss
    (Emitted value instead of an instance of Error)

     ⚠️  PostCSS Loader

    Previous source map found, but options.sourceMap isn't set.
    In this case the loader will discard the source map entirely for
    performance reasons.
    See https://github.com/postcss/postcss-loader#sourcemap for more
    information.